### PR TITLE
Changes to cope with ROCm 1.5.x

### DIFF
--- a/add4/Makefile
+++ b/add4/Makefile
@@ -1,34 +1,4 @@
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-	CXXFLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-	$(warning )
-	$(warning ***************************************************)
-	$(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-	$(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-	$(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-	$(warning ***************************************************)
-	$(warning )
-endif
-#### GCC system includes workaround ####
-
-CXXFLAGS += -std=c++11 -O3
+CXXFLAGS += -O3
 
 all:  gpu-stream-hip
 

--- a/cuda-stream/Makefile
+++ b/cuda-stream/Makefile
@@ -4,37 +4,7 @@ ifeq (,$(HIP_PATH))
 endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-	CXXFLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-	$(warning )
-	$(warning ***************************************************)
-	$(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-	$(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-	$(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-	$(warning ***************************************************)
-	$(warning )
-endif
-#### GCC system includes workaround ####
-
-CXXFLAGS += -std=c++11 -O3
+CXXFLAGS += -O3
 
 stream: stream.cpp
 ifeq ($(shell which $(HIPCC) > /dev/null; echo $$?), 0)

--- a/gpu-burn/BurnKernel.cpp
+++ b/gpu-burn/BurnKernel.cpp
@@ -14,6 +14,14 @@
 // ---------------------------------------------------------------------------
 namespace gpuburn {
 
+constexpr int BurnKernel::cRandSeed;
+constexpr float BurnKernel::cUseMem;
+constexpr uint32_t BurnKernel::cRowSize;
+constexpr uint32_t BurnKernel::cMatrixSize;
+constexpr uint32_t BurnKernel::cBlockSize;
+constexpr float BurnKernel::cAlpha;
+constexpr float BurnKernel::cBeta;
+
 BurnKernel::BurnKernel(int hipDevice)
     : mHipDevice(hipDevice), mRunKernel(false),
     mDeviceAdata(NULL), mDeviceBdata(NULL), mDeviceCdata(NULL)

--- a/gpu-burn/Makefile
+++ b/gpu-burn/Makefile
@@ -12,7 +12,7 @@ ifeq (${HIP_PLATFORM}, nvcc)
     CPPFLAGS += -arch=compute_20
 endif
 ifeq (${HIP_PLATFORM}, hcc)
-    CPPFLAGS += -stdlib=libc++
+    CPPFLAGS +=
 endif
 
 GPUBURN_SRC = $(wildcard *.cpp)

--- a/reduction/Makefile
+++ b/reduction/Makefile
@@ -4,37 +4,7 @@ ifeq (,$(HIP_PATH))
 endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-	CXXFLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-	$(warning )
-	$(warning ***************************************************)
-	$(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-	$(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-	$(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-	$(warning ***************************************************)
-	$(warning )
-endif
-#### GCC system includes workaround ####
-
-CXXFLAGS += -std=c++11 -O3
+CXXFLAGS += -O3
 
 reduction: reduction.cpp
 ifeq ($(shell which $(HIPCC) > /dev/null; echo $$?), 0)

--- a/rodinia_3.0/common/make.config
+++ b/rodinia_3.0/common/make.config
@@ -40,36 +40,6 @@ ifeq ($(prof),1)
     HIPCC_FLAGS += -DPROFILING
 endif
 
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-    HIPCC_FLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-    $(warning )
-    $(warning ***************************************************)
-    $(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-    $(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-    $(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-    $(warning ***************************************************)
-    $(warning )
-endif
-#### GCC system includes workaround ####
-
 #---
 #Automated infrastructure for running tests.
 #

--- a/rtm8/Makefile
+++ b/rtm8/Makefile
@@ -4,37 +4,7 @@ ifeq (,$(HIP_PATH))
 endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-    CXXFLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-    $(warning )
-    $(warning ***************************************************)
-    $(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-    $(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-    $(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-    $(warning ***************************************************)
-    $(warning )
-endif
-#### GCC system includes workaround ####
-
-CXXFLAGS += -std=c++11 -O3
+CXXFLAGS += -O3
 
 rtm8: rtm8.cpp
 ifeq ($(shell which $(HIPCC) > /dev/null; echo $$?), 0)

--- a/rtm8/build_hip.sh
+++ b/rtm8/build_hip.sh
@@ -19,8 +19,6 @@ then
     rm rtm8_hip
 fi
 
-GCC_VER=4.8
-
-echo "hipcc -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$GCC_VER -I /usr/include/c++/$GCC_VER -std=c++11 -O3 -o rtm8_hip rtm8.cpp"
-$HIP_PATH/bin/hipcc -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$GCC_VER -I /usr/include/c++/$GCC_VER -std=c++11 -O3 -o rtm8_hip rtm8.cpp
+echo "hipcc -O3 -o rtm8_hip rtm8.cpp"
+$HIP_PATH/bin/hipcc -O3 -o rtm8_hip rtm8.cpp
 

--- a/strided-access/Makefile
+++ b/strided-access/Makefile
@@ -4,37 +4,7 @@ ifeq (,$(HIP_PATH))
 endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-    CXXFLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-    $(warning )
-    $(warning ***************************************************)
-    $(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-    $(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-    $(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-    $(warning ***************************************************)
-    $(warning )
-endif
-#### GCC system includes workaround ####
-
-CXXFLAGS += -std=c++11 -O3
+CXXFLAGS += -O3
 
 strided-access: benchmark-hip.cpp
 ifeq ($(shell which $(HIPCC) > /dev/null; echo $$?), 0)

--- a/vectorAdd/Makefile
+++ b/vectorAdd/Makefile
@@ -19,36 +19,6 @@ all: $(EXECUTABLE) test
 
 CXXFLAGS =-g
 
-#### GCC system includes workaround ####
-GCC_VER ?= 4.8
-
-GCC_CUR_VER = $(shell gcc -dumpversion)
-GPP_CUR_VER = $(shell g++ -dumpversion)
-
-GCC_CUR = 0
-GPP_CUR = 1
-
-ifeq ($(findstring $(GCC_VER),$(GCC_CUR_VER)),$(GCC_VER))
-GCC_CUR = GCC_VER
-endif
-
-ifeq ($(findstring $(GCC_VER),$(GPP_CUR_VER)),$(GCC_VER))
-GPP_CUR = GCC_VER
-endif
-
-ifeq ($(GCC_CUR), $(GPP_CUR))
-    CXXFLAGS += -I /usr/include/x86_64-linux-gnu -I /usr/include/x86_64-linux-gnu/c++/$(GCC_VER) -I /usr/include/c++/$(GCC_VER)
-else
-    $(warning )
-    $(warning ***************************************************)
-    $(warning *** The supported version of gcc and g++ is $(GCC_VER) ***)
-    $(warning ***    Current default version of gcc is $(GCC_CUR_VER)    ***)
-    $(warning ***    Current default version of g++ is $(GPP_CUR_VER)    ***)
-    $(warning ***************************************************)
-    $(warning )
-endif
-#### GCC system includes workaround ####
-
 CXX=$(HIPCC)
 
 


### PR DESCRIPTION
- removed GCC header search workarounds
- fix gpu-burn codes to cope with new hcc