### PR TITLE
HIP-Examples-Applications hipLaunchKernelGGL

### DIFF
--- a/HIP-Examples-Applications/BinomialOption/BinomialOption.cpp
+++ b/HIP-Examples-Applications/BinomialOption/BinomialOption.cpp
@@ -166,7 +166,7 @@ class BinomialOption
 };
 
 
-__global__ void binomial_options(hipLaunchParm lp,
+__global__ void binomial_options(
                                  int numSteps,
                                  const float4* randArray,
                                  float4* out)
@@ -353,7 +353,7 @@ BinomialOption::runKernels()
     // Record the start event
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(binomial_options,
+    hipLaunchKernelGGL(binomial_options,
                   dim3(samplesPerVectorWidth),
                   dim3(localThreads),
                   0, 0,

--- a/HIP-Examples-Applications/BitonicSort/BitonicSort.cpp
+++ b/HIP-Examples-Applications/BitonicSort/BitonicSort.cpp
@@ -165,7 +165,7 @@ class BitonicSort
 
 
 
-__global__ void bitonicSort(hipLaunchParm lp, unsigned int * theArray,
+__global__ void bitonicSort(unsigned int * theArray,
                             const unsigned int stage,
                             const unsigned int passOfStage,
                             const unsigned int direction)
@@ -339,7 +339,7 @@ BitonicSort::runKernels(void)
         {
         hipEventRecord(start, NULL);
 
-        hipLaunchKernel(bitonicSort,
+        hipLaunchKernelGGL(bitonicSort,
                         dim3(globalThreads/localThreads),
                         dim3(localThreads),
                         0, 0,

--- a/HIP-Examples-Applications/FastWalshTransform/FastWalshTransform.cpp
+++ b/HIP-Examples-Applications/FastWalshTransform/FastWalshTransform.cpp
@@ -108,8 +108,8 @@ class FastWalshTransform
 };
 
 
-__global__ void fastWalshTransform(hipLaunchParm lp,
-			                       float * tArray,
+__global__ void fastWalshTransform(
+			           float * tArray,
                                    int   step  )
 {
 		unsigned int tid = hipThreadIdx_x+hipBlockIdx_x*hipBlockDim_x;
@@ -206,7 +206,7 @@ FastWalshTransform::runKernels(void)
     // Record the start event
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(fastWalshTransform,
+    hipLaunchKernelGGL(fastWalshTransform,
                     dim3(globalThreads/localThreads),
                     dim3(localThreads),
                     0, 0,

--- a/HIP-Examples-Applications/FloydWarshall/FloydWarshall.cpp
+++ b/HIP-Examples-Applications/FloydWarshall/FloydWarshall.cpp
@@ -198,8 +198,8 @@ unsigned int uintMin(unsigned int a, unsigned int b)
  * provided with the sample
  */
 
-__global__ void floydWarshallPass(hipLaunchParm lp,
-		                          unsigned int * pathDistanceBuffer,
+__global__ void floydWarshallPass(
+		                  unsigned int * pathDistanceBuffer,
                                   unsigned int * pathBuffer        ,
                                   const unsigned int numNodes      ,
                                   const unsigned int pass)
@@ -373,7 +373,7 @@ FloydWarshall::runKernels(void)
     // Record the start event
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(floydWarshallPass,
+    hipLaunchKernelGGL(floydWarshallPass,
                   dim3(globalThreads[0]/localThreads[0],globalThreads[1]/localThreads[1]),
                   dim3(localThreads[0],localThreads[1]),
                   0, 0,

--- a/HIP-Examples-Applications/HelloWorld/HelloWorld.cpp
+++ b/HIP-Examples-Applications/HelloWorld/HelloWorld.cpp
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
 using namespace std;
 
-__global__ void helloworld(hipLaunchParm lp, char* in, char* out)
+__global__ void helloworld(char* in, char* out)
 {
 	int num = hipThreadIdx_x + hipBlockDim_x * hipBlockIdx_x;
 	out[num] = in[num] + 1;
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
 
     hipMemcpy(inputBuffer, input, (strlength + 1) * sizeof(char), hipMemcpyHostToDevice);
 
-	hipLaunchKernel(helloworld,
+	hipLaunchKernelGGL(helloworld,
                   dim3(1),
                   dim3(strlength),
                   0, 0,

--- a/HIP-Examples-Applications/Histogram/Histogram.cpp
+++ b/HIP-Examples-Applications/Histogram/Histogram.cpp
@@ -30,9 +30,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
  * @param   binResult block-histogram array
  */
 __global__
-void histogram256(hipLaunchParm lp,
-                        unsigned int* data,
-                        unsigned int* binResult)
+void histogram256(
+                  unsigned int* data,
+                  unsigned int* binResult)
 {
     HIP_DYNAMIC_SHARED(unsigned char, sharedArray);
     size_t localId = hipThreadIdx_x;
@@ -209,7 +209,7 @@ Histogram::runKernels(void)
 
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(histogram256,
+    hipLaunchKernelGGL(histogram256,
                     dim3(globalThreads/localThreads),
                     dim3(localThreads),
                     groupSize * binSize * sizeof(unsigned char), 0,

--- a/HIP-Examples-Applications/MatrixMultiplication/MatrixMultiplication.cpp
+++ b/HIP-Examples-Applications/MatrixMultiplication/MatrixMultiplication.cpp
@@ -196,7 +196,7 @@ class MatrixMultiplication
 /* Output tile size : 4x4 = Each thread computes 16 float values*/
 /* Required global threads = (widthC / 4, heightC / 4) */
 /* This kernel runs on 7xx and CPU as they don't have hardware local memory */
-__global__ void mmmKernel( hipLaunchParm lp,
+__global__ void mmmKernel(
 			 float4 *matrixA,
                          float4 *matrixB,
                          float4* matrixC,
@@ -335,7 +335,7 @@ hipMemcpy(din0, input0,width0 * height0 * sizeof(float), hipMemcpyHostToDevice);
 hipMemcpy(din1, input1,width1 * height1 * sizeof(float), hipMemcpyHostToDevice);
 
 
-hipLaunchKernel(mmmKernel,
+hipLaunchKernelGGL(mmmKernel,
                   dim3((width1/4)/blockSize,(height0/4)/blockSize),
                   dim3(blockSize,blockSize),
                   0, 0,

--- a/HIP-Examples-Applications/PrefixSum/PrefixSum.cpp
+++ b/HIP-Examples-Applications/PrefixSum/PrefixSum.cpp
@@ -220,10 +220,10 @@ class PrefixSum
 };
 
 __global__
-void group_prefixSum( hipLaunchParm lp,  float * output,
-					 float * input,
-					 const unsigned int length,
-					 const unsigned int idxOffset) {
+void group_prefixSum( float * output,
+		      float * input,
+		      const unsigned int length,
+		      const unsigned int idxOffset) {
 	int localId = hipThreadIdx_x;
 	int localSize = hipBlockDim_x;
 	int globalIdx = hipBlockIdx_x;
@@ -283,7 +283,7 @@ void group_prefixSum( hipLaunchParm lp,  float * output,
  * @param length	lenght of the input data
  */
 __global__
-void global_prefixSum( hipLaunchParm lp,
+void global_prefixSum( 
 		       float * buffer,
                        unsigned int offset,
 		       unsigned int length) {
@@ -352,7 +352,7 @@ PrefixSum::runGroupKernel(unsigned int offset)
                     localThreads;
 
 buf=(offset>1) ? outputBuffer  : inputBuffer;
-hipLaunchKernel(group_prefixSum,
+hipLaunchKernelGGL(group_prefixSum,
                   dim3(globalThreads/localThreads),
                   dim3(localThreads),
                   0, 0,
@@ -376,7 +376,7 @@ PrefixSum::runGlobalKernel(unsigned int offset)
     globalThreads = ((globalThreads + localThreads - 1) / localThreads) *
                     localThreads;
 
-hipLaunchKernel(global_prefixSum,
+hipLaunchKernelGGL(global_prefixSum,
                   dim3(globalThreads/localThreads),
                   dim3(localThreads),
                   0, 0,

--- a/HIP-Examples-Applications/RecursiveGaussian/RecursiveGaussian.cpp
+++ b/HIP-Examples-Applications/RecursiveGaussian/RecursiveGaussian.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
  * input image is transposed by reading the data into a block
  * and writing it to output image
  */
-__global__ void transpose_kernel(hipLaunchParm lp, 
+__global__ void transpose_kernel( 
                                  uchar4 *output,
                                  uchar4  *input,
                                  unsigned int    width,
@@ -68,7 +68,7 @@ __global__ void transpose_kernel(hipLaunchParm lp,
  *      iheight  - image height
  *      a0-a3, b1, b2, coefp, coefn - gaussian parameters
  */
-__global__ void RecursiveGaussian_kernel(hipLaunchParm lp,
+__global__ void RecursiveGaussian_kernel(
                                        const uchar4* input, uchar4* output, 
 				       const int width, const int height, 
 				       const float a0, const float a1, 
@@ -314,7 +314,7 @@ RecursiveGaussian::runKernels()
 
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(RecursiveGaussian_kernel,
+    hipLaunchKernelGGL(RecursiveGaussian_kernel,
                     dim3(width/blockSizeX, 1/blockSizeY),
                     dim3(blockSizeX,blockSizeY),
                     0, 0,
@@ -328,7 +328,7 @@ RecursiveGaussian::runKernels()
 
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(transpose_kernel,
+    hipLaunchKernelGGL(transpose_kernel,
                     dim3(width/blockSize,height/blockSize),
                     dim3(blockSize,blockSize),
                     0, 0,
@@ -345,7 +345,7 @@ RecursiveGaussian::runKernels()
     new_width = height
     new_height = width */
     hipEventRecord(start, NULL);
-    hipLaunchKernel(RecursiveGaussian_kernel,
+    hipLaunchKernelGGL(RecursiveGaussian_kernel,
                     dim3(height/blockSizeX, 1/blockSizeY),
                     dim3(blockSizeX,blockSizeY),
                     0, 0,
@@ -359,7 +359,7 @@ RecursiveGaussian::runKernels()
 
     hipEventRecord(start, NULL);
     // Enqueue final Transpose Kernel
-    hipLaunchKernel(transpose_kernel,
+    hipLaunchKernelGGL(transpose_kernel,
                     dim3(height/blockSize,width/blockSize),
                     dim3(blockSize,blockSize),
                     0, 0,

--- a/HIP-Examples-Applications/SimpleConvolution/SimpleConvolution.cpp
+++ b/HIP-Examples-Applications/SimpleConvolution/SimpleConvolution.cpp
@@ -40,7 +40,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
  * @param nExWidth          Size of padded input width
  */
 
-__global__ void simpleNonSeparableConvolution(hipLaunchParm lp,  unsigned int  * input,
+__global__ void simpleNonSeparableConvolution(unsigned int  * input,
                                               float  * mask, int  * output,
                                               uint2  inputDimensions,uint2  maskDimensions,
                                               unsigned int nExWidth)
@@ -103,7 +103,7 @@ __global__ void simpleNonSeparableConvolution(hipLaunchParm lp,  unsigned int  *
  * @param filterSize  length of row filter vector
  * @param exInputDimensions      dimensions of padded input
  */
- __global__ void simpleSeparableConvolutionPass1(hipLaunchParm lp, unsigned int  * input,
+ __global__ void simpleSeparableConvolutionPass1(unsigned int  * input,
                                                  float  * rowFilter, float  * tmpOutput,
                                                  uint2  inputDimensions, unsigned int  filterSize,
                                                  uint2  exInputDimensions)
@@ -142,7 +142,7 @@ __global__ void simpleNonSeparableConvolution(hipLaunchParm lp,  unsigned int  *
  * @param filterSize  length of col filter vector
  * @param exInputDimensions      dimensions of padded input
  */
- __global__ void simpleSeparableConvolutionPass2(hipLaunchParm lp,  float  * input,
+ __global__ void simpleSeparableConvolutionPass2(float  * input,
                                                  float  * colFilter, int  * output,
                                                  uint2  inputDimensions, unsigned int  filterSize,
                                                  uint2  exInputDimensions)
@@ -284,7 +284,7 @@ SimpleConvolution::runNonSeparableKernels(void)
     globalThreads = (width*height + localThreads - 1) / localThreads;
     globalThreads *= localThreads;
 
-    hipLaunchKernel(simpleNonSeparableConvolution,
+    hipLaunchKernelGGL(simpleNonSeparableConvolution,
                     dim3(globalThreads/localThreads),
                     dim3(localThreads),
                     0, 0,
@@ -306,7 +306,7 @@ SimpleConvolution::runSeparableKernels(void)
     globalThreads = (globalSizePass1 + localThreads - 1)/localThreads;
     globalThreads *= localThreads;
 
-    hipLaunchKernel(simpleSeparableConvolutionPass1,
+    hipLaunchKernelGGL(simpleSeparableConvolutionPass1,
                     dim3(globalThreads/localThreads),
                     dim3(localThreads),
                     0, 0,
@@ -318,7 +318,7 @@ SimpleConvolution::runSeparableKernels(void)
     globalThreads = (globalSizePass2 + localThreads - 1)/localThreads;
     globalThreads *= localThreads;
 
-    hipLaunchKernel(simpleSeparableConvolutionPass2,
+    hipLaunchKernelGGL(simpleSeparableConvolutionPass2,
                     dim3(globalThreads/localThreads),
                     dim3(localThreads),
                     0, 0,

--- a/HIP-Examples-Applications/dct/dct.cpp
+++ b/HIP-Examples-Applications/dct/dct.cpp
@@ -244,7 +244,7 @@ getIdx(unsigned int blockIdx, unsigned int blockIdy, unsigned int localIdx, unsi
  * @param inverse  flag to perform inverse DCT
  */
 
-__global__ void DCTKernel(hipLaunchParm lp,
+__global__ void DCTKernel(
 	                      float * output,
                           float * input,
                           float * dct8x8,
@@ -393,7 +393,7 @@ DCT::runKernels(void)
     // Record the start event
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(DCTKernel,
+    hipLaunchKernelGGL(DCTKernel,
                   dim3(width/blockWidth, height/blockWidth),
                   dim3(blockWidth,blockWidth),
                   0, 0,

--- a/HIP-Examples-Applications/dwtHaar1D/dwtHaar1D.cpp
+++ b/HIP-Examples-Applications/dwtHaar1D/dwtHaar1D.cpp
@@ -202,7 +202,7 @@ class DwtHaar1D
 };
 
 
-__global__ void dwtHaar1D(hipLaunchParm lp,
+__global__ void dwtHaar1D(
                           float *inSignal,
                           float *coefsSignal,
                           float *AverageSignal,
@@ -412,7 +412,7 @@ int DwtHaar1D::runDwtHaar1DKernel()
     // Record the start event
     hipEventRecord(start, NULL);
 
-    hipLaunchKernel(dwtHaar1D,
+    hipLaunchKernelGGL(dwtHaar1D,
                   dim3(globalThreads/localThreads),
                   dim3(localThreads),
                   0, 0,


### PR DESCRIPTION
Fix for the compiler error in HIP-Examples-Applications due to the hipLaunchKernel signature changes.