### PR TITLE
Add HIP-Examples for OpenMP Hello World

### DIFF
--- a/openmp-helloworld/CMakeLists.txt
+++ b/openmp-helloworld/CMakeLists.txt
@@ -1,0 +1,29 @@
+project(openmp_helloworld)
+
+cmake_minimum_required(VERSION 3.16)
+
+# Search for rocm in common locations
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hip /opt/rocm)
+
+# Find HIP
+# The user may override AMDGPU_TARGETS defined in the HIP config file
+# to select the AMDGPU archs to compile for.
+# ex. set(AMDGPU_TARGETS "gfx803;gfx900;gfx906")
+find_package(hip REQUIRED)
+
+# Find OpenMP
+find_package(OpenMP REQUIRED)
+
+# Set compiler and linker
+set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
+set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+set(CMAKE_BUILD_TYPE Release)
+
+# Source files
+set(CPP_SOURCES ${CMAKE_SOURCE_DIR}/openmp_helloworld.cpp)
+
+# Preparing the executable
+add_executable(test_openmp_helloworld ${CPP_SOURCES})
+target_compile_options(test_openmp_helloworld PRIVATE ${OpenMP_CXX_FLAGS})
+target_link_libraries(test_openmp_helloworld PRIVATE hip::device ${OpenMP_CXX_FLAGS})
+

--- a/openmp-helloworld/Makefile
+++ b/openmp-helloworld/Makefile
@@ -1,0 +1,30 @@
+HIP_PATH?= $(wildcard /opt/rocm/hip)
+ifeq (,$(HIP_PATH))
+	HIP_PATH=../../..
+endif
+
+HIPCC=$(HIP_PATH)/bin/hipcc
+CXX=$(HIPCC)
+CXXFLAGS =-fopenmp
+
+SOURCES = openmp_helloworld.cpp
+
+EXECUTABLE=./openmp_helloworld.exe
+
+.PHONY: test
+
+
+all: $(EXECUTABLE) test
+
+
+$(EXECUTABLE):
+	$(CXX) $(CXXFLAGS) $(SOURCES) -o $@
+
+
+test: $(EXECUTABLE)
+	$(EXECUTABLE)
+
+
+clean:
+	rm -f $(EXECUTABLE) *.o
+

--- a/openmp-helloworld/README.md
+++ b/openmp-helloworld/README.md
@@ -1,0 +1,20 @@
+# Simple OpenMP hello world example written directly to the HIP interface.
+
+## Requirements
+* Installed ROCm 3.9 or newer. See  [ROCm Installation Guide](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html).
+
+
+## How to run this code:
+
+### Using Make:
+* To build and run: `make`.
+* To clean the environment: `make clean`.
+
+
+### Using CMake:
+* To build: `mkdir -p build; cd build; cmake ..; make`
+* To run the test: `./test_openmp_helloworld`
+* To clean the build environment: `make clean`
+
+**Note:** You may override `AMDGPU_TARGETS` in the HIP config file by modifying the CMakeLists.txt.
+

--- a/openmp-helloworld/openmp_helloworld.cpp
+++ b/openmp-helloworld/openmp_helloworld.cpp
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2020-present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// OpenMP program to print Hello World
+// using C language is supported by HIP
+
+// HIP header
+#include <hip/hip_runtime.h>
+
+//OpenMP header
+#include <omp.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+__global__
+void hip_helloworld(unsigned omp_id)
+{
+    printf("Hello World... from HIP thread = %u\n", omp_id);
+}
+
+int main(int argc, char* argv[])
+{
+    // Beginning of parallel region
+    #pragma omp parallel
+    {
+        printf("Hello World... from OMP thread = %d\n",
+               omp_get_thread_num());
+
+        hipLaunchKernelGGL(hip_helloworld, dim3(1), dim3(1), 0, 0, omp_get_thread_num());
+    }
+    // Ending of parallel region
+
+    hipLaunchKernelGGL(hip_helloworld, dim3(1), dim3(1), 0, 0, /*id=*/ 0);
+    hipStreamSynchronize(0);
+
+    printf ("PASSED!\n");
+    return 0;
+}

--- a/test_all.sh
+++ b/test_all.sh
@@ -78,8 +78,17 @@ echo
 echo "==== Rodinia ===="
 cd rodinia_3.0/hip
 make clean -j ${HIP_MAKEJ}
-make test 
+make test
 cd ..
 
-
+# openmp-helloworld
+echo
+echo "==== OpenMP Hello World ===="
+cd openmp-helloworld
+mkdir -p build
+cd build
+cmake ..
+make
+./test_openmp_helloworld
+cd ../..
 


### PR DESCRIPTION
Many projects such as math libraries may use ROCm installed omp.h.
This example shows how to compile and run a simple OpenMP app,
and does not require additional includes or linking directives.

Fixes: SWDEV-257119