### PR TITLE
Don't pass raw -j to make

### DIFF
--- a/test_all.sh
+++ b/test_all.sh
@@ -77,7 +77,7 @@ echo
 : ${HIP_MAKEJ:="4"}
 echo "==== Rodinia ===="
 cd rodinia_3.0/hip
-make clean -j ${HIP_MAKEJ}
+make clean -j$(nproc) ${HIP_MAKEJ}
 make test
 cd ..
 


### PR DESCRIPTION
`-j` means to use unlimited amount of workers. That is not a good idea on low core count machines, or big core count machines with not enough memory.

It shouldn't be an issue for `clean` target, but it is bad practice.

Use `nproc`.