### PR TITLE
Update hip header path

### DIFF
--- a/gpu-burn/Makefile
+++ b/gpu-burn/Makefile
@@ -4,9 +4,8 @@ ifeq (,$(HIP_PATH))
 endif
 
 
-HCC_PATH ?= /opt/rocm/hcc
 HIP_PLATFORM = $(shell $(HIP_PATH)/bin/hipconfig --platform)
-HIP_INCLUDE = -I${HIP_PATH}/include -I${HCC_PATH}/include
+HIP_INCLUDE = -I${HIP_PATH}/../include
 BUILD_DIR ?= build
 
 HIPCC = ${HIP_PATH}/bin/hipcc


### PR DESCRIPTION
it will fix below issue
#error "hip_version.h has moved to /opt/rocm-xxx/include/hip and package include paths have changed. Provide include path as /opt/rocm-xxx/include when using cmake packages."